### PR TITLE
Update Skelestruder_Assembly.md

### DIFF
--- a/Skelestruder_Assembly.md
+++ b/Skelestruder_Assembly.md
@@ -62,15 +62,21 @@ Most of the parts of the skelestruder are 3D printed. One of the nice features o
 
 The material recommendations in the printed parts table are based on a mix of experience, expectations, strength, density, glass temp, etc. You can deviate. Let me know what you find. Remember, I am going for light so I want good stiffness/density. For example, motor spider needs to be stiff so I recommend PLA since it has a much higher modulus of elasticity. Here’s a table where I ranked various properties. Note that HT PLA needs to be annealed and it can shrink/distort during that process if you are not careful, leading to fitment issues.
 
-| Material | Weight | Stiffness | Stiffness / Weight | Glass Temperature | Detail Resolve | Environmental Friendliness | Post-processing | Ease of Printing |
+| Material | Weight | Stiffness | Stiffness / Weight | Deflection Temperature | Detail Resolve | Environmental Friendliness | Post-processing | Ease of Printing |
 |----------|--------|-----------|--------------------|-------------------|----------------|----------------------------|-----------------|------------------|
 | PLA (HT) | B      | A         | A                  | C (A)             | A              | A                          | A               | A                |
-| PET      | B      | C         | C+                 | B                 | B              | B                          | C               | B+               |
-| ABS      | A-     | C         | B-                 | A                 | D              | D                          | A               | C                |
-| Nylon    | A      | A         | A                  | C+                | ?              | D                          | ?               | D                |
+| PETG      | B      | C         | C+                 | B                 | B              | F                          | C               | B+               |
+| ABS      | A-     | C         | B-                 | A                 | D              | F                          | A               | C                |
+| Nylon    | A      | F         | F                 | A-                | B              | F                          | ?               | D                |
+| PETG-CF    | B      | A+         | A-                  | A+                | A-              | F                          | ?               | A-                |
+| Nylon-CF    | A-      | A+         | A+                  | A+                | A-              | F                          | ?               | A-                |
 ||
 
 Anecdotally, I have been testing all parts 100% PLA because I have a bunch of spools to burn through. I have had no problems. Others have also printed all parts in 100% PLA without any issues. Note that the extruder fan is blowing cool air over the lower portion the entire time, so very little is exposed to stagnant radiant heat, mainly the cooling nozzle and P rack. The cooling fan is on some even for PETG printing and P rack seems far enough away that I see no issues. I am not in an enclosure though.
+
+Nylon is too flexible to be used for anything structural - it can be used for the fan nozzle but there is no real advantage to doing so.
+
+Carbon fiber reinforced Nylon and PETG are both stiffer than PLA, have higher heat deflection temperatures than even ABS, and are incredibly low-warp and dimensionally stable.  Anecdotally, printing 100% in either of these gives the best results and noticeably reduces ghosting artifacts over PLA.  Highly recommended, just be aware of the effects of printing CF containing filaments on your nozzle first.
 
 I design parts to minimize unique slicer settings, changing orientation, and post-processing. Ideally just print and go. That said, some post-print dressing is helpful. Before starting, clean up parts where they interface, such as removing burrs and blobs. Pre-tap threads in these holes by fully screwing and unscrewing a screw (will make assembly easier):
 


### PR DESCRIPTION
Changes to the material comparison table (and the reasoning behind said changes):

- **Changed glass transition temperature to heat deflection temperature.**

  Glass transition temperature is not useful.  It only has a very formal, material science definition that has nothing to do with actual mechanical properties. Heat deflection temperature however is very useful - it's the temperature a fixed amount of force (268 psi) will result in the same amount of bending/sagging/deflection.  This is what actually matters and what I believe jltx intended to convey with this table.

  As for why glass transition temperature is not useful... take Nylon and PETG for example.  Nylon 6,6's (Nylon 645/Taulman Bridge) glass transition temperature is 52°C.  It's heat deflection temperature is **90° C**.  In comparison, PETG's heat deflection temperature is 70°C, lower than it's glass transition of 80-88° C.

- **Changed PET to PETG.** 

  PET≠ PETG.  PETG is 99% of all filament calling itself PET.  Actual PET/PETT is very uncommon and specialized when it comes to 3D printing filament, and has different properties than those in the table.

- **Changed environmental friendliness of Nylon and ABS to F.**

  The only environmentally friendly plastic on the list is PLA.  All others are not environmentally friendly at all, they are environmentally unfriendly.  That is an F, not a D, which implies some level of environmentally friendliness.

- **Changed PETG's environmental friendliness to an F.**  

  I assume it was B originally because it is recyclable.  This is true - for PET.  PETG is not recycled because the glycol modification makes it much more difficult to process.  California had to pass a law specifically excluding PETG from the "1" recycling code, or any recycling code for that matter.

  And even if it were PET (which it isn't), it would still get an F.  The curbside recycling efficiency is about 21%, meaning if you recycle 5 water bottles, 4 of them just go to the landfill anyway and one gets recycled.  But, even that is better than nothing, right?  Sure, in terms of cost.  

  In terms of environmental impact, no.  Plastics of any kind, including PET, derive all their desirable properties from having longer molecular chains.  The recycling process of grinding and then melting it back into feedstock also degrades the length of the molecular chains and the resulting product is inferior in every way, and by a big margin.  So much so that PET recycling has not had any measurable impact on demand for virgin PET resin.  

  In other words, recycling PET has not had any effect on how much new PET we actually make, and the only mechanism by which plastic presents an environmental problem is simply that it exists at all (and sticks around for a very long time).  So PET recycling doesn't make it more environmentally friendly.  And again, that's PET, which is not PETG.  PETG would have the same problems if it were recycled at all, but it generally isn't.

  If we're being concerned about the environment, I think we should at least correctly represent the impact, and in this case, recycling is not reducing that impact.  I wish it was different, but that's the unfortunate reality, at least as it stands right now.

- **Corrected the stiffness rating of Nylon to an F.**  

  Nylon is not rigid at all, and far too flexible for use in any structural components of the skelestruder. 
 
  The most rigid Nylon filament available, Taulman 910, has a modulus of ~75,000 PSI.  PETG, on the other hand, has a modulus of well over ~290,00 PSI.  And Taulman 910 is remarkably rigid for Nylon, all the other types are half or even less that rigidity.  It is really only potentially useful for the fan nozzle, but there isn't much advantage I can see to using it for this regardless.

- **Added PETG-CF and Nylon-CF.**  

  I have printed an operational Skelestruder that I have used for some time now in both carbon fiber reinforced PETG and Nylon, and both of them are arguably the best options.  Nylon-CF is stiffer than everything on the table, including PLA, and PETG-CF is even stiffer than Nylon-CF.  Nylon-CF is light weight.  Both of them have higher heat deflection temperatures than that of ABS.  They are also both wonderfully easy to print as the CF reinforcement makes them very low-warp and quite dimensionally stable.  All parts, including parts specified to be printed in PLA only, can be printed in either and they are more durable.


Also added a brief anecdotal description of nylon, nylon-cf, ant petg cf.  